### PR TITLE
[bugfix] fix error of wrongly remove newline character '\n'.

### DIFF
--- a/formatting.py
+++ b/formatting.py
@@ -194,11 +194,10 @@ def format_codes(filename):
         while lines and not lines[-1].strip():
             lines.pop()       
 
-        for line in lines:
+        for i, line in enumerate(lines):
             line = tab2spaces(line)
-            line = formattail(line, is_last_line = (line == lines[-1]))
+            line = formattail(line, is_last_line = (i == (len(lines) - 1)))
             line = move_braces_to_next_line(line)
-
             file_temp.write(line)
         file_temp.close()
         file.close()


### PR DESCRIPTION
原代码中199行判断line是否为最后一行的方式有问题，`(line == lines[-1])`表示的是当前行的内容和最后一行相同，这不能作为判断最后一行的依据，例如如下代码：
```
#ifdef MACRO_XXX
void func1(int a, int b)
{
...
}
#else
void func1(int a)
{
..
}
#endif

int func2()
{
...
}

```
当最后一行"}"之后紧跟一个“\n”时，即最后一行为“}\n”，此时，#else的上一行和#endif的上一行均为“}\n”，与最后一行相同，因此会被错误判定为最后一行，从而在执行脚本后丢失“\n”，变成如下的情况：
```
#ifdef MACRO_XXX
void func1(int a, int b)
{
...
}#else
void func1(int a)
{
..
}#endif

int func2()
{
...
}
```
因此，修改判断是否为最后一行的表达式，改为用索引判断，从而修复如上问题。